### PR TITLE
feat: Inserido envio dos endereços dos orgãos de defesa do consumidor no Rio de Janeiro

### DIFF
--- a/src/NFe/Core/Nota.php
+++ b/src/NFe/Core/Nota.php
@@ -1830,7 +1830,16 @@ abstract class Nota implements Node
             Util::appendNode($info_adic, 'infAdFisco', $this->getAdicionais(true));
         }
         // TODO: adicionar informações adicionais somente na NFC-e?
-        $_complemento = Produto::addNodeInformacoes($tributos, $info_adic, 'infCpl');
+        $_complemento = Produto::getInformacoesProduto($tributos);
+        if ($this->getEmitente()->getEndereco()->getMunicipio()->getEstado()->getCodigo() == 33) {
+            $informações_complementares = array(
+                $_complemento,
+                'PROCON-RJ: tel. 151, end. Av. Rio Branco, 25 - 5º andar, Centro/RJ.',
+                'CODECON: tel. 0800 282 7060, end. R. da Ajuda, 5, 2º andar, sala 201, Centro/RJ',
+            );
+            $_complemento = implode(' ', $informações_complementares);                
+        }
+        Util::appendNode($info_adic, 'infCpl', $_complemento);         
         $this->getTotal()->setComplemento($_complemento);
         if (!is_null($this->getObservacoes())) {
             $_observacoes = $this->getObservacoes();

--- a/src/NFe/Entity/Produto.php
+++ b/src/NFe/Entity/Produto.php
@@ -605,7 +605,7 @@ class Produto extends Total
         return $this;
     }
 
-    public static function addNodeInformacoes($tributos, $element, $name = null)
+    public static function getInformacoesProduto($tributos)
     {
         $detalhes = [];
         $formatos = [
@@ -632,6 +632,13 @@ class Produto extends Total
             $ultimo = ' e ' . array_pop($detalhes);
         }
         $texto = 'Trib. aprox.: ' . implode(', ', $detalhes) . $ultimo . '. ' . $fonte;
+        
+        return $texto;
+    }
+    
+    public static function addNodeInformacoes($tributos, $element, $name = null)
+    {
+        $texto = Produto::getInformacoesProduto($tributos);
         Util::appendNode($element, is_null($name) ? 'infAdProd' : $name, $texto);
         return $texto;
     }


### PR DESCRIPTION
http://www.fazenda.rj.gov.br/sefaz/content/conn/UCMServer/path/Contribution%20Folders/site_fazenda/informacao/sistemaseletronicos/dfe/manuais/DF-e_NFC-e.pdf?lve

INFORMAÇÕES COMPLEMENTARES
As informações exigidas pela Lei nº 5.817/10 devem constar da NFC-e. No DANFE NFC-e, serão
impressas no campo destinado a “Mensagem de Interesse do Contribuinte”.
“Art. 1º. É obrigatória a inclusão de telefone e endereço do órgão de fiscalização do Estado do
Rio de Janeiro em Defesa do Consumidor – Programa de Orientação e Proteção ao
Consumidor - PROCON–RJ e da Comissão de Defesa do Consumidor da Assembleia
Legislativa do Estado do Rio de Janeiro – ALERJ nos documentos fiscais emitidos pelos
estabelecimentos comerciais do Estado do Rio de Janeiro.”
O número do PROCON-RJ é 151 e o endereço Av. Rio Branco, 25 - 5º andar, Centro/RJ.
O número da CODECON (Comissão de Defesa do Consumidor) é 0800 282 7060 e o endereço é R.
da Alfândega, 8 – Centro/RJ.
Vale lembrar que o programa de sorteio público “Cupom Mania” foi extinto pelo Decreto nº 45.093/15.
Portanto, as informações relativas a ele devem ser retiradas dos documentos em que vinham sendo
impressas.