### PR TITLE
fix: verifica se a tag card existe antes de verificar a tpIntegra

### DIFF
--- a/src/NFe/Entity/Pagamento.php
+++ b/src/NFe/Entity/Pagamento.php
@@ -656,11 +656,13 @@ class Pagamento implements Node
         );
         $card = $element->getElementsByTagName('card');
         if ($card->length > 0) {
-            $integrado = Util::loadNode($element, 'tpIntegra');
+            $integrado = Util::loadNode($card->item(0), 'tpIntegra');
             if (is_null($integrado) && $this->isCartao()) {
                 throw new \Exception('Tag "tpIntegra" do campo "Integrado" não encontrada', 404);
             }
             $this->setIntegrado($integrado);
+        } else {
+            $this->setIntegrado(0);
         }
         $this->setCredenciadora(Util::loadNode($element, 'CNPJ'));
         $autorizacao = Util::loadNode($element, 'cAut');

--- a/src/NFe/Entity/Pagamento.php
+++ b/src/NFe/Entity/Pagamento.php
@@ -654,12 +654,14 @@ class Pagamento implements Node
                 'Tag "vPag" do campo "Valor" não encontrada'
             )
         );
-        $card = Util::loadNode($element, 'card');
-        $integrado = Util::loadNode($element, 'tpIntegra');
-        if (!is_null($card) && is_null($integrado) && $this->isCartao()) {
-            throw new \Exception('Tag "tpIntegra" do campo "Integrado" não encontrada', 404);
-        }
-        $this->setIntegrado($integrado ?? 0);
+        $card = $element->getElementsByTagName('card');
+        if ($card->length > 0) {
+            $integrado = Util::loadNode($element, 'tpIntegra');
+            if (is_null($integrado) && $this->isCartao()) {
+                throw new \Exception('Tag "tpIntegra" do campo "Integrado" não encontrada', 404);
+            }
+            $this->setIntegrado($integrado);
+        }        
         $this->setCredenciadora(Util::loadNode($element, 'CNPJ'));
         $autorizacao = Util::loadNode($element, 'cAut');
         if (is_null($autorizacao) && $this->isCartao() && is_numeric($this->getCredenciadora())) {

--- a/src/NFe/Entity/Pagamento.php
+++ b/src/NFe/Entity/Pagamento.php
@@ -661,7 +661,7 @@ class Pagamento implements Node
                 throw new \Exception('Tag "tpIntegra" do campo "Integrado" não encontrada', 404);
             }
             $this->setIntegrado($integrado);
-        }        
+        }
         $this->setCredenciadora(Util::loadNode($element, 'CNPJ'));
         $autorizacao = Util::loadNode($element, 'cAut');
         if (is_null($autorizacao) && $this->isCartao() && is_numeric($this->getCredenciadora())) {

--- a/src/NFe/Entity/Pagamento.php
+++ b/src/NFe/Entity/Pagamento.php
@@ -654,11 +654,12 @@ class Pagamento implements Node
                 'Tag "vPag" do campo "Valor" não encontrada'
             )
         );
+        $card = Util::loadNode($element, 'card');
         $integrado = Util::loadNode($element, 'tpIntegra');
-        if (is_null($integrado) && $this->isCartao()) {
+        if (!is_null($card) && is_null($integrado) && $this->isCartao()) {
             throw new \Exception('Tag "tpIntegra" do campo "Integrado" não encontrada', 404);
         }
-        $this->setIntegrado($integrado);
+        $this->setIntegrado($integrado ?? 0);
         $this->setCredenciadora(Util::loadNode($element, 'CNPJ'));
         $autorizacao = Util::loadNode($element, 'cAut');
         if (is_null($autorizacao) && $this->isCartao() && is_numeric($this->getCredenciadora())) {

--- a/src/NFe/Entity/Pagamento.php
+++ b/src/NFe/Entity/Pagamento.php
@@ -662,7 +662,7 @@ class Pagamento implements Node
             }
             $this->setIntegrado($integrado);
         } else {
-            $this->setIntegrado(0);
+            $this->setIntegrado('0');
         }
         $this->setCredenciadora(Util::loadNode($element, 'CNPJ'));
         $autorizacao = Util::loadNode($element, 'cAut');


### PR DESCRIPTION
fix: verifica se a tag card existe antes de verificar a tpIntegra, pois a tag card não é obrigatória.
![image](https://github.com/mazinsw/nfe-api/assets/52977305/98aa7d79-8add-44b6-8aab-ca008e5b9a4e)
