### PR TITLE
fix: remove a obrigatoriedade de informar a tag cPais

### DIFF
--- a/src/NFe/Entity/Endereco.php
+++ b/src/NFe/Entity/Endereco.php
@@ -317,8 +317,7 @@ class Endereco implements Node
         $this->getPais()->setCodigo(
             Util::loadNode(
                 $element,
-                'cPais',
-                'Tag "cPais" do objeto "Pais" não encontrada'
+                'cPais'
             )
         );
         $this->getPais()->setNome(


### PR DESCRIPTION
remove a obrigatoriedade de informar a tag cPais pois a tag é de ocorrência 0-1
![image](https://github.com/mazinsw/nfe-api/assets/52977305/a6bff751-b2d7-48b2-b5a1-77159d781185)
